### PR TITLE
fixing onPush and onFinish for iOS

### DIFF
--- a/packages/brightcove-video/ios/RNTBrightcove.xcodeproj/project.pbxproj
+++ b/packages/brightcove-video/ios/RNTBrightcove.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		870C5C8D1F99E57F00092A65 /* RNTBrightcoveFullscreenManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 870C5C811F99E57F00092A65 /* RNTBrightcoveFullscreenManager.m */; };
 		870C5C8E1F99E57F00092A65 /* RNTBrightcoveCloseButtonView.m in Sources */ = {isa = PBXBuildFile; fileRef = 870C5C861F99E57F00092A65 /* RNTBrightcoveCloseButtonView.m */; };
 		870C5C8F1F99E57F00092A65 /* RNTFullscreenAutoPresentingView.m in Sources */ = {isa = PBXBuildFile; fileRef = 870C5C871F99E57F00092A65 /* RNTFullscreenAutoPresentingView.m */; };
+		8B97CCFE2075C2F500427647 /* RNTBrightcoveVideoEventSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B97CCFD2075C2F500427647 /* RNTBrightcoveVideoEventSignal.m */; };
 		9DF2A7AC1F27EB3A0015AC73 /* RNTBrightcoveManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DF2A7AA1F27EB3A0015AC73 /* RNTBrightcoveManager.m */; };
 /* End PBXBuildFile section */
 
@@ -47,6 +48,8 @@
 		870C5C851F99E57F00092A65 /* RNTBrightcoveFullscreenManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNTBrightcoveFullscreenManager.h; sourceTree = "<group>"; };
 		870C5C861F99E57F00092A65 /* RNTBrightcoveCloseButtonView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNTBrightcoveCloseButtonView.m; sourceTree = "<group>"; };
 		870C5C871F99E57F00092A65 /* RNTFullscreenAutoPresentingView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNTFullscreenAutoPresentingView.m; sourceTree = "<group>"; };
+		8B97CCFC2075C2F500427647 /* RNTBrightcoveVideoEventSignal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNTBrightcoveVideoEventSignal.h; sourceTree = "<group>"; };
+		8B97CCFD2075C2F500427647 /* RNTBrightcoveVideoEventSignal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNTBrightcoveVideoEventSignal.m; sourceTree = "<group>"; };
 		9DF2A79B1F27EB1B0015AC73 /* libRNTBrightcove.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNTBrightcove.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9DF2A7A91F27EB3A0015AC73 /* RNTBrightcoveManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNTBrightcoveManager.h; sourceTree = "<group>"; };
 		9DF2A7AA1F27EB3A0015AC73 /* RNTBrightcoveManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNTBrightcoveManager.m; sourceTree = "<group>"; };
@@ -100,6 +103,8 @@
 				870C5C7A1F99E57F00092A65 /* RNTFullscreenPresentingAutoRotatingViewController.m */,
 				9DF2A7A91F27EB3A0015AC73 /* RNTBrightcoveManager.h */,
 				9DF2A7AA1F27EB3A0015AC73 /* RNTBrightcoveManager.m */,
+				8B97CCFC2075C2F500427647 /* RNTBrightcoveVideoEventSignal.h */,
+				8B97CCFD2075C2F500427647 /* RNTBrightcoveVideoEventSignal.m */,
 			);
 			path = RNTBrightcove;
 			sourceTree = "<group>";
@@ -163,6 +168,7 @@
 			files = (
 				870C5C8D1F99E57F00092A65 /* RNTBrightcoveFullscreenManager.m in Sources */,
 				870C5C8B1F99E57F00092A65 /* RNTBrightcoveViewController.m in Sources */,
+				8B97CCFE2075C2F500427647 /* RNTBrightcoveVideoEventSignal.m in Sources */,
 				870C5C8F1F99E57F00092A65 /* RNTFullscreenAutoPresentingView.m in Sources */,
 				870C5C8C1F99E57F00092A65 /* RNTBrightcoveManager.m in Sources */,
 				870C5C8A1F99E57F00092A65 /* RNTFullscreenPresentingAutoRotatingViewController.m in Sources */,

--- a/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveFullscreenManager.h
+++ b/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveFullscreenManager.h
@@ -1,5 +1,6 @@
 
 #import <React/RCTBridgeModule.h>
+#import "RNTBrightcoveVideoEventSignal.h"
 
 @interface RNTBrightcoveFullscreenManager : NSObject <RCTBridgeModule>
 @end

--- a/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveFullscreenManager.m
+++ b/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveFullscreenManager.m
@@ -13,7 +13,7 @@
 RCT_EXPORT_MODULE(BrightcoveFullscreenPlayer);
 
 RCT_EXPORT_METHOD(playVideo:(NSDictionary *)video) {
-    
+
     __weak RNTBrightcoveFullscreenManager *weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
         [weakSelf presentFullscreenVideo: video];
@@ -21,30 +21,31 @@ RCT_EXPORT_METHOD(playVideo:(NSDictionary *)video) {
 }
 
 - (void)presentFullscreenVideo:(NSDictionary *)video {
-    
+
     RNTBrightcoveView* brightcoveView = [[RNTBrightcoveView alloc] initWithEventDispatcher:nil];
-    
+  [[RNTBrightcoveVideoEventSignal allocWithZone: nil] onPlay];
+  
     brightcoveView.translatesAutoresizingMaskIntoConstraints = NO;
-    
+
     brightcoveView.videoId = video[@"videoId"];
     brightcoveView.accountId = video[@"accountId"];
     brightcoveView.policyKey = video[@"policyKey"];
     brightcoveView.autoplay = YES;
     brightcoveView.hideFullScreenButton = YES;
-    
+
     self.videoContainerViewController = [RNTBrightcoveViewController new];
     [self.videoContainerViewController addVideoView: brightcoveView];
     
     NSDictionary *views = NSDictionaryOfVariableBindings(brightcoveView);
-    
+
     NSArray* horizontalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[brightcoveView]|" options: 0 metrics: nil views: views];
     NSArray* verticalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[brightcoveView]|" options: 0 metrics: nil views: views];
-    
+
     [self.videoContainerViewController.view addConstraints:horizontalConstraints];
     [self.videoContainerViewController.view addConstraints:verticalConstraints];
-    
+
     [[self rootViewController] presentViewController:self.videoContainerViewController animated:YES completion:nil];
-    
+
 }
 
 - (UIViewController *)rootViewController {

--- a/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveVideoEventSignal.h
+++ b/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveVideoEventSignal.h
@@ -1,0 +1,17 @@
+//
+//  RNTBrightcoveVideoEventSignal.h
+//  RNTBrightcove
+//
+//  Created by Beau Ayres on 5/4/18.
+//  Copyright © 2018 Osedea. All rights reserved.
+//
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RNTBrightcoveVideoEventSignal : RCTEventEmitter <RCTBridgeModule>
+
+-(void) onPlay;
+-(void) onClose;
+
+@end

--- a/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveVideoEventSignal.m
+++ b/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveVideoEventSignal.m
@@ -1,0 +1,46 @@
+//
+//  RNTBrightcoveVideoEventSignal.m
+//  RNTBrightcove
+//
+//  Created by Beau Ayres on 5/4/18.
+//  Copyright © 2018 Osedea. All rights reserved.
+//
+
+#import "RNTBrightcoveVideoEventSignal.h"
+
+@interface RNTBrightcoveVideoEventSignal ()
+#define ONPLAYNOTIFICATION @"onPlayNotification"
+#define ONCLOSENOTIFICATION @"onCloseNotification"
+@end
+
+@implementation RNTBrightcoveVideoEventSignal
+
+RCT_EXPORT_MODULE();
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[ONPLAYNOTIFICATION, ONCLOSENOTIFICATION];
+}
+
++ (id)allocWithZone:(NSZone *)zone {
+  static RNTBrightcoveVideoEventSignal *sharedRNTBrightcoveVideoEventSignal = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedRNTBrightcoveVideoEventSignal = [super allocWithZone:zone];
+  });
+  return sharedRNTBrightcoveVideoEventSignal;
+}
+
+-(void)onPlay; {
+  [self sendEventWithName:@"onPlayNotification" body:NULL];
+}
+
+-(void)onClose; {
+  @try {
+  [self sendEventWithName:@"onCloseNotification" body:NULL];
+  } @catch (NSException *error) {
+    NSLog(@"onClose was called after a live refresh, this could cause a crash if not caught");
+  }
+}
+
+@end

--- a/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveViewController.m
+++ b/packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveViewController.m
@@ -2,6 +2,7 @@
 #import "RNTBrightcoveViewController.h"
 #import "RNTBrightcoveSVGCloseButtonView.h"
 #import "RNTBrightcoveView.h"
+#import "RNTBrightcoveVideoEventSignal.h"
 
 @interface RNTBrightcoveViewController ()
 @property (nonatomic, weak) RNTBrightcoveView* videoView;
@@ -10,7 +11,7 @@
 @implementation RNTBrightcoveViewController
 
 - (void)loadView {
-    
+
     RNTBrightcoveCloseButtonView *bcView = [[RNTBrightcoveCloseButtonView alloc] initWithFrame: CGRectZero];
     bcView.delegate = self;
     self.view = bcView;
@@ -19,6 +20,7 @@
 #pragma mark - RNTBrightcoveCloseButtonViewDelegate
 
 - (void)closeButtonTapped {
+  [[RNTBrightcoveVideoEventSignal allocWithZone: nil] onClose];
     if ([self presentingViewController]) {
         [self.videoView pauseVideo];
         [[self presentingViewController] dismissViewControllerAnimated:YES completion:NULL];
@@ -31,7 +33,7 @@
 }
 
 - (void)addVideoView:(RNTBrightcoveView *)videoView {
-    
+
     if (videoView) {
         [self.view addSubview:videoView];
         self.videoView = videoView;
@@ -39,7 +41,7 @@
 }
 
 - (void)destroyVideoView {
-    
+
     [self.videoView removeFromSuperview];
     self.videoView = nil;
 }


### PR DESCRIPTION
This is a fix for 'onPlay' and 'onFinish' if you use the directToFullscreen prop, as they do not work as of the most recent version of their brightcove module. 


Leaving this here, currently implemented in app through a shell script. 
Annoyed with the allocator i had to use but they must have changed how RCTEventEmitter work since i last implemented one.
If this is helpful to anybody else, i might submit a pr to timesuk. I'm also happy to look into the other props, they just require more event emitters.
